### PR TITLE
Cache timestamp check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>fi.hsl.transitdata</groupId>
     <artifactId>transitdata-pubtrans-source</artifactId>
-    <version>0.1.2</version>
+    <version>0.2.0</version>
     <packaging>jar</packaging>
 
     <repositories>
@@ -18,7 +18,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <pulsar.version>2.1.0-incubating</pulsar.version>
-        <common.version>0.2.1</common.version>
+        <common.version>0.2.2</common.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,12 @@
             <artifactId>mssql-jdbc</artifactId>
             <version>6.2.2.jre8</version>
         </dependency>
-
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/fi/hsl/transitdata/pulsarpubtransconnect/Main.java
+++ b/src/main/java/fi/hsl/transitdata/pulsarpubtransconnect/Main.java
@@ -70,19 +70,16 @@ public class Main {
             ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
             log.info("Starting scheduler");
 
-            scheduler.scheduleAtFixedRate(new Runnable() {
-                @Override
-                public void run() {
-                    try {
-                        if(connector.checkPrecondition()) {
-                            connector.queryAndProcessResults();
-                        }
-                        else {
-                            log.error("Pubtrans poller precondition failed, skipping the current poll cycle.");
-                        }
-                    } catch (Exception e) {
-                        log.error("Error at Pubtrans scheduler", e);
+            scheduler.scheduleAtFixedRate(() -> {
+                try {
+                    if(connector.checkPrecondition()) {
+                        connector.queryAndProcessResults();
                     }
+                    else {
+                        log.error("Pubtrans poller precondition failed, skipping the current poll cycle.");
+                    }
+                } catch (Exception e) {
+                    log.error("Error at Pubtrans scheduler", e);
                 }
             }, 0, 1, TimeUnit.SECONDS);
         }

--- a/src/main/java/fi/hsl/transitdata/pulsarpubtransconnect/Main.java
+++ b/src/main/java/fi/hsl/transitdata/pulsarpubtransconnect/Main.java
@@ -65,7 +65,7 @@ public class Main {
             PulsarApplication app = PulsarApplication.newInstance(config);
             PulsarApplicationContext context = app.getContext();
 
-            final PubtransConnector connector = new PubtransConnector(connection, context.getJedis(), context.getProducer(), config, type);
+            final PubtransConnector connector = PubtransConnector.newInstance(connection, context.getJedis(), context.getProducer(), config, type);
 
             ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
             log.info("Starting scheduler");
@@ -74,7 +74,12 @@ public class Main {
                 @Override
                 public void run() {
                     try {
-                        connector.queryAndProcessResults();
+                        if(connector.checkPrecondition()) {
+                            connector.queryAndProcessResults();
+                        }
+                        else {
+                            log.error("Pubtrans poller precondition failed, skipping the current poll cycle.");
+                        }
                     } catch (Exception e) {
                         log.error("Error at Pubtrans scheduler", e);
                     }

--- a/src/main/java/fi/hsl/transitdata/pulsarpubtransconnect/PubtransConnector.java
+++ b/src/main/java/fi/hsl/transitdata/pulsarpubtransconnect/PubtransConnector.java
@@ -1,13 +1,19 @@
 package fi.hsl.transitdata.pulsarpubtransconnect;
 
+import com.sun.scenario.effect.Offset;
 import com.typesafe.config.Config;
+import fi.hsl.common.transitdata.TransitdataProperties;
 import org.apache.pulsar.client.api.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import redis.clients.jedis.Jedis;
 
 import java.sql.*;
+import java.time.Duration;
+import java.time.OffsetDateTime;
 import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 import java.util.Calendar;
 import java.util.Queue;
 import java.util.TimeZone;
@@ -20,30 +26,45 @@ public class PubtransConnector {
     private long queryStartTime;
 
     private String queryString;
+    private boolean enableCacheCheck;
+    private int cacheMaxAgeInMins;
 
     private PubtransTableHandler handler;
+    private Jedis jedis;
 
+    private PubtransConnector() {}
 
-    public PubtransConnector(Connection connection, Jedis jedis, Producer<byte[]> producer, Config config, PubtransTableType tableType) {
+    public static PubtransConnector newInstance(Connection connection,
+                                                Jedis jedis,
+                                                Producer<byte[]> producer,
+                                                Config config,
+                                                PubtransTableType tableType) throws RuntimeException {
+        PubtransConnector connector = new PubtransConnector();
 
-        this.connection = connection;
-        this.queryString = queryString(config);
+        connector.connection = connection;
+        connector.jedis = jedis;
+        connector.queryString = queryString(config);
+
+        connector.enableCacheCheck = config.getBoolean("application.enableCacheTimestampCheck");
+        connector.cacheMaxAgeInMins = config.getInt("application.cacheMaxAgeInMinutes");
+
+        log.info("Cache pre-condition enabled: " + connector.enableCacheCheck + " with max age "+ connector.cacheMaxAgeInMins);
 
         log.info("TableType: " + tableType);
         switch (tableType) {
             case ROI_ARRIVAL:
-                this.handler = new ArrivalHandler(jedis, producer);
+                connector.handler = new ArrivalHandler(jedis, producer);
                 break;
             case ROI_DEPARTURE:
-                this.handler = new DepartureHandler(jedis, producer);
+                connector.handler = new DepartureHandler(jedis, producer);
                 break;
             default:
                 throw new IllegalArgumentException("Table type not supported");
         }
-
+        return connector;
     }
 
-    private String queryString(Config config) {
+    private static String queryString(Config config) {
         String longName = config.getString("pubtrans.longName");
         String shortName = config.getString("pubtrans.shortName");
 
@@ -56,6 +77,26 @@ public class PubtransConnector {
                 .append(shortName)
                 .append(".LastModifiedUTCDateTime > ? ")
                 .toString();
+    }
+
+    public boolean checkPrecondition() {
+        String lastUpdate = jedis.get(TransitdataProperties.KEY_LAST_CACHE_UPDATE_TIMESTAMP);
+        if (lastUpdate != null) {
+            OffsetDateTime dt = OffsetDateTime.parse(lastUpdate, DateTimeFormatter.ISO_INSTANT);
+            return isCacheValid(dt, cacheMaxAgeInMins);
+        }
+        else {
+            log.error("Could not find last cache update timestamp from redis");
+            return false;
+        }
+    }
+
+    static boolean isCacheValid(OffsetDateTime lastCacheUpdate, final int cacheMaxAgeInMins) {
+
+        OffsetDateTime now = OffsetDateTime.now();
+        final long minutesSinceUpdate = Duration.between(lastCacheUpdate, now).get(ChronoUnit.MINUTES);
+        log.debug("Current time is " + now.toString() + ", last update " + lastCacheUpdate.toString() + " => mins from prev update: " + minutesSinceUpdate);
+        return minutesSinceUpdate <= cacheMaxAgeInMins;
     }
 
     public void queryAndProcessResults() {
@@ -76,7 +117,6 @@ public class PubtransConnector {
         finally {
             if (resultSet != null)  try { resultSet.close(); } catch (Exception e) {log.error(e.getMessage());}
             if (statement != null)  try { statement.close(); } catch (Exception e) {log.error(e.getMessage());}
-            //if (connection != null)  try { connection.close(); } catch (Exception e) {}
         }
     }
 

--- a/src/main/java/fi/hsl/transitdata/pulsarpubtransconnect/PubtransConnector.java
+++ b/src/main/java/fi/hsl/transitdata/pulsarpubtransconnect/PubtransConnector.java
@@ -1,6 +1,5 @@
 package fi.hsl.transitdata.pulsarpubtransconnect;
 
-import com.sun.scenario.effect.Offset;
 import com.typesafe.config.Config;
 import fi.hsl.common.transitdata.TransitdataProperties;
 import org.apache.pulsar.client.api.*;
@@ -11,13 +10,9 @@ import redis.clients.jedis.Jedis;
 import java.sql.*;
 import java.time.Duration;
 import java.time.OffsetDateTime;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
-import java.util.Calendar;
 import java.util.Queue;
-import java.util.TimeZone;
 
 public class PubtransConnector {
 

--- a/src/main/java/fi/hsl/transitdata/pulsarpubtransconnect/PubtransConnector.java
+++ b/src/main/java/fi/hsl/transitdata/pulsarpubtransconnect/PubtransConnector.java
@@ -12,6 +12,7 @@ import java.sql.*;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.Calendar;
@@ -80,9 +81,12 @@ public class PubtransConnector {
     }
 
     public boolean checkPrecondition() {
+        if (!enableCacheCheck)
+            return true;
+
         String lastUpdate = jedis.get(TransitdataProperties.KEY_LAST_CACHE_UPDATE_TIMESTAMP);
         if (lastUpdate != null) {
-            OffsetDateTime dt = OffsetDateTime.parse(lastUpdate, DateTimeFormatter.ISO_INSTANT);
+            OffsetDateTime dt = OffsetDateTime.parse(lastUpdate, DateTimeFormatter.ISO_DATE_TIME);
             return isCacheValid(dt, cacheMaxAgeInMins);
         }
         else {
@@ -97,7 +101,7 @@ public class PubtransConnector {
         //Java8 does not support getting duration as minutes directly.
         final long secondsSinceUpdate = Duration.between(lastCacheUpdate, now).get(ChronoUnit.SECONDS);
         final long minutesSinceUpdate = Math.floorDiv(secondsSinceUpdate, 60);
-        log.debug("Current time is " + now.toString() + ", last update " + lastCacheUpdate.toString() + " => mins from prev update: " + minutesSinceUpdate);
+        log.debug("Current time " + now.toString() + ", last update " + lastCacheUpdate.toString() + " => mins from prev update: " + minutesSinceUpdate);
         return minutesSinceUpdate <= cacheMaxAgeInMins;
     }
 

--- a/src/main/java/fi/hsl/transitdata/pulsarpubtransconnect/PubtransConnector.java
+++ b/src/main/java/fi/hsl/transitdata/pulsarpubtransconnect/PubtransConnector.java
@@ -94,7 +94,9 @@ public class PubtransConnector {
     static boolean isCacheValid(OffsetDateTime lastCacheUpdate, final int cacheMaxAgeInMins) {
 
         OffsetDateTime now = OffsetDateTime.now();
-        final long minutesSinceUpdate = Duration.between(lastCacheUpdate, now).get(ChronoUnit.MINUTES);
+        //Java8 does not support getting duration as minutes directly.
+        final long secondsSinceUpdate = Duration.between(lastCacheUpdate, now).get(ChronoUnit.SECONDS);
+        final long minutesSinceUpdate = Math.floorDiv(secondsSinceUpdate, 60);
         log.debug("Current time is " + now.toString() + ", last update " + lastCacheUpdate.toString() + " => mins from prev update: " + minutesSinceUpdate);
         return minutesSinceUpdate <= cacheMaxAgeInMins;
     }

--- a/src/main/java/fi/hsl/transitdata/pulsarpubtransconnect/PubtransTableHandler.java
+++ b/src/main/java/fi/hsl/transitdata/pulsarpubtransconnect/PubtransTableHandler.java
@@ -11,6 +11,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.Queue;
 
 public abstract class PubtransTableHandler {
@@ -36,46 +37,80 @@ public abstract class PubtransTableHandler {
         this.lastModifiedTimeStamp = ts;
     }
 
-    private Map<String, String> getJourneyInfo(long dvjId) {
-        String key = TransitdataProperties.REDIS_PREFIX_DVJ + Long.toString(dvjId);
-        return jedis.hgetAll(key);
-    }
-
-    private String getStopId(long jppId) {
-        String key = TransitdataProperties.REDIS_PREFIX_JPP + Long.toString(jppId);
-        return jedis.get(key);
-    }
-
     //TODO finetune SQL so that we can use common method to parse most of the fields. now derived classes contain a lot of duplicate code.
     abstract public Queue<TypedMessageBuilder> handleResultSet(ResultSet resultSet) throws SQLException;
 
-    Optional<TypedMessageBuilder> createMessage(String key, long eventTime, long dvjId, long jppId, byte[] data) {
-        Map<String, String> journeyInfo = getJourneyInfo(dvjId);
-        if (journeyInfo != null) {
-            boolean containsAll = journeyInfo.containsKey(TransitdataProperties.KEY_DIRECTION) &&
-                    journeyInfo.containsKey(TransitdataProperties.KEY_ROUTE_NAME) &&
-                    journeyInfo.containsKey(TransitdataProperties.KEY_START_TIME) &&
-                    journeyInfo.containsKey(TransitdataProperties.KEY_OPERATING_DAY);
-            if (!containsAll) {
-                log.error("Missing fields in journey data from Redis for DatedVehicleJourneyId " + dvjId);
-                return Optional.empty();
+
+    class JourneyInfo {
+        String direction;
+        String routeName;
+        String startTime;
+        String operatingDay;
+
+        JourneyInfo(Map<String, String> map) {
+            direction = map.get(TransitdataProperties.KEY_DIRECTION);
+            routeName = map.get(TransitdataProperties.KEY_ROUTE_NAME);
+            startTime = map.get(TransitdataProperties.KEY_START_TIME);
+            operatingDay = map.get(TransitdataProperties.KEY_OPERATING_DAY);
+            if (!isValid()) {
+                //Let's print more info for debugging purposes:
+                log.error("JourneyInfo is missing some fields. Content: " + this.toString());
             }
-        } else {
-            log.error("No journey data found from Redis for DatedVehicleJourneyId " + dvjId);
-            return Optional.empty();
         }
-        String stopId = getStopId(jppId);
-        return Optional.of(
-                producer.newMessage()
-                .key(key)
-                .eventTime(eventTime)
-                .property(TransitdataProperties.KEY_DVJ_ID, Long.toString(dvjId))
-                .property(TransitdataProperties.KEY_PROTOBUF_SCHEMA, schema.toString())
-                .property(TransitdataProperties.KEY_DIRECTION, journeyInfo.get(TransitdataProperties.KEY_DIRECTION))
-                .property(TransitdataProperties.KEY_ROUTE_NAME, journeyInfo.get(TransitdataProperties.KEY_ROUTE_NAME))
-                .property(TransitdataProperties.KEY_START_TIME, journeyInfo.get(TransitdataProperties.KEY_START_TIME))
-                .property(TransitdataProperties.KEY_OPERATING_DAY, journeyInfo.get(TransitdataProperties.KEY_OPERATING_DAY))
-                .property(TransitdataProperties.KEY_STOP_ID, stopId)
-                .value(data));
+
+        boolean isValid() {
+            return direction != null && routeName != null &&
+                   startTime != null && operatingDay != null;
+        }
+
+        @Override
+        public String toString() {
+            return new StringBuilder()
+                    .append("direction: ").append(direction)
+                    .append(" routeName: ").append(routeName)
+                    .append(" startTime: ").append(startTime)
+                    .append(" operatingDay: ").append(operatingDay)
+                    .toString();
+        }
+    }
+
+    private Optional<JourneyInfo> getJourneyInfo(long dvjId) {
+        String key = TransitdataProperties.REDIS_PREFIX_DVJ + Long.toString(dvjId);
+        Optional<Map<String, String>> maybeJourneyInfoMap = Optional.ofNullable(jedis.hgetAll(key));
+
+        return maybeJourneyInfoMap
+                .map(JourneyInfo::new)
+                .filter(JourneyInfo::isValid);
+    }
+
+    private Optional<String> getStopId(long jppId) {
+        String key = TransitdataProperties.REDIS_PREFIX_JPP + Long.toString(jppId);
+        return Optional.ofNullable(jedis.get(key));
+    }
+
+    Optional<TypedMessageBuilder> createMessage(String key, long eventTime, long dvjId, long jppId, byte[] data) {
+        Optional<JourneyInfo> maybeJourneyInfo = getJourneyInfo(dvjId);
+        if (!maybeJourneyInfo.isPresent()) {
+            log.error("Could not find valid JourneyInfo from Redis for dvjId " + dvjId);
+        }
+        Optional<String> maybeStopId = getStopId(jppId);
+        if (!maybeStopId.isPresent()) {
+            log.error("Could not find StopId from Redis for dvjId " + dvjId);
+        }
+
+        return maybeJourneyInfo.flatMap(journeyInfo ->
+                maybeStopId.map(stopId ->
+                    producer.newMessage()
+                            .key(key)
+                            .eventTime(eventTime)
+                            .property(TransitdataProperties.KEY_DVJ_ID, Long.toString(dvjId))
+                            .property(TransitdataProperties.KEY_PROTOBUF_SCHEMA, schema.toString())
+                            .property(TransitdataProperties.KEY_DIRECTION, journeyInfo.direction)
+                            .property(TransitdataProperties.KEY_ROUTE_NAME, journeyInfo.routeName)
+                            .property(TransitdataProperties.KEY_START_TIME, journeyInfo.startTime)
+                            .property(TransitdataProperties.KEY_OPERATING_DAY, journeyInfo.operatingDay)
+                            .property(TransitdataProperties.KEY_STOP_ID, stopId)
+                            .value(data))
+                );
     }
 }

--- a/src/main/resources/arrival.conf
+++ b/src/main/resources/arrival.conf
@@ -19,3 +19,10 @@ pubtrans {
   longName="[ptROI_Community].[dbo].[Arrival]"
   shortName="ARR"
 }
+
+application {
+  enableCacheTimestampCheck=true
+  enableCacheTimestampCheck=${?ENABLE_CACHE_TIMESTAMP_CHECK}
+  cacheMaxAgeInMinutes=180
+  cacheMaxAgeInMinutes=${?CACHE_MAX_AGE_IN_MINS}
+}

--- a/src/main/resources/departure.conf
+++ b/src/main/resources/departure.conf
@@ -19,3 +19,10 @@ pubtrans {
   longName="[ptROI_Community].[dbo].[Departure]"
   shortName="DEP"
 }
+
+application {
+  enableCacheTimestampCheck=true
+  enableCacheTimestampCheck=${?ENABLE_CACHE_TIMESTAMP_CHECK}
+  cacheMaxAgeInMinutes=180
+  cacheMaxAgeInMinutes=${?CACHE_MAX_AGE_IN_MINS}
+}

--- a/src/test/java/fi/hsl/transitdata/pulsarpubtransconnect/PubtransConnectorTest.java
+++ b/src/test/java/fi/hsl/transitdata/pulsarpubtransconnect/PubtransConnectorTest.java
@@ -1,0 +1,25 @@
+package fi.hsl.transitdata.pulsarpubtransconnect;
+
+import org.junit.Test;
+
+import java.time.OffsetDateTime;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class PubtransConnectorTest {
+    @Test
+    public void testCacheMaxAge() {
+        final OffsetDateTime now = OffsetDateTime.now();
+        final int maxAgeInMins = 120;
+
+        assertTrue(PubtransConnector.isCacheValid(now, maxAgeInMins));
+        assertTrue(PubtransConnector.isCacheValid(now.minusMinutes(1), maxAgeInMins));
+        assertTrue(PubtransConnector.isCacheValid(now.minusMinutes(119), maxAgeInMins));
+        assertTrue(PubtransConnector.isCacheValid(now.minusMinutes(120), maxAgeInMins));
+
+        assertFalse(PubtransConnector.isCacheValid(now.minusMinutes(121), maxAgeInMins));
+        assertFalse(PubtransConnector.isCacheValid(now.minusMinutes(200), maxAgeInMins));
+
+    }
+}


### PR DESCRIPTION
Currently application discards messages if it doesn't find necessary metadata from redis. Problems with this approach:
- some valid messages can be discarded
- if redis is emptied for some reason our whole pipeline will "> /dev/null"

We can mitigate this problem by checking a timestamp when was Redis filled last time and use this as pre-condition to our processing. 

dependency: https://github.com/HSLdevcom/transitdata-cache-bootstrapper/pull/5 
(however can be merged and deployed with env variable 

ENABLE_CACHE_TIMESTAMP_CHECK=false

This hopefully fixes this https://gitlab.hsl.fi/transitdata/gtfs-realtime-architecture/issues/117

also added prints about redis content if it's not valid.