### PR TITLE
Feat/unify timestamps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>fi.hsl.transitdata</groupId>
     <artifactId>transitdata-pubtrans-source</artifactId>
-    <version>0.2.0</version>
+    <version>0.3.0</version>
     <packaging>jar</packaging>
 
     <repositories>
@@ -18,7 +18,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <pulsar.version>2.1.0-incubating</pulsar.version>
-        <common.version>0.2.3</common.version>
+        <common.version>0.4.0</common.version>
     </properties>
 
     <dependencies>

--- a/src/main/java/fi/hsl/transitdata/pulsarpubtransconnect/ArrivalHandler.java
+++ b/src/main/java/fi/hsl/transitdata/pulsarpubtransconnect/ArrivalHandler.java
@@ -1,5 +1,6 @@
 package fi.hsl.transitdata.pulsarpubtransconnect;
 
+import fi.hsl.common.pulsar.PulsarApplicationContext;
 import fi.hsl.common.transitdata.TransitdataProperties;
 import fi.hsl.common.transitdata.proto.PubtransTableProtos;
 import org.apache.pulsar.client.api.Producer;
@@ -14,8 +15,8 @@ import java.util.Queue;
 
 public class ArrivalHandler extends PubtransTableHandler {
 
-    public ArrivalHandler(Jedis jedis, Producer<byte[]> producer) {
-        super(jedis, producer, TransitdataProperties.ProtobufSchema.PubtransRoiArrival);
+    public ArrivalHandler(PulsarApplicationContext context) {
+        super(context, TransitdataProperties.ProtobufSchema.PubtransRoiArrival);
     }
 
     @Override

--- a/src/main/java/fi/hsl/transitdata/pulsarpubtransconnect/ArrivalHandler.java
+++ b/src/main/java/fi/hsl/transitdata/pulsarpubtransconnect/ArrivalHandler.java
@@ -28,31 +28,34 @@ public class ArrivalHandler extends PubtransTableHandler {
         while (resultSet.next()) {
             PubtransTableProtos.Common.Builder commonBuilder = PubtransTableProtos.Common.newBuilder();
 
-            //This is the LastModifiedUTCDateTime from the database. It will be used in the actual protobuf message and
-            //the Pulsar message eventTime field
-            long eventTime = resultSet.getTimestamp(16).getTime();
-            if (eventTime > tempTimeStamp)
-                tempTimeStamp = eventTime;
-            final long eventTimeInSecs = eventTime / 1000;
-
             //We're hardcoding the version number to proto file to ease syncing with changes, however we still need to set it since it's a required field
             commonBuilder.setSchemaVersion(commonBuilder.getSchemaVersion());
             commonBuilder.setId(resultSet.getLong(1));
             commonBuilder.setIsOnDatedVehicleJourneyId(resultSet.getLong(2));
-            if (resultSet.getBytes(3) != null) commonBuilder.setIsOnMonitoredVehicleJourneyId(resultSet.getLong(3));
+            if (resultSet.getBytes(3) != null)
+                commonBuilder.setIsOnMonitoredVehicleJourneyId(resultSet.getLong(3));
             commonBuilder.setJourneyPatternSequenceNumber(resultSet.getInt(4));
             commonBuilder.setIsTimetabledAtJourneyPatternPointGid(resultSet.getLong(5));
             commonBuilder.setVisitCountNumber(resultSet.getInt(6));
-            if (resultSet.getBytes(7) != null) commonBuilder.setIsTargetedAtJourneyPatternPointGid(resultSet.getLong(7));
-            if (resultSet.getBytes(8) != null) commonBuilder.setWasObservedAtJourneyPatternPointGid(resultSet.getLong(8));
-            if (resultSet.getBytes(9) != null) commonBuilder.setTimetabledLatestDateTime(resultSet.getString(9));
-            if (resultSet.getBytes(10) != null) commonBuilder.setTargetDateTime(resultSet.getString(10));
-            if (resultSet.getBytes(11) != null) commonBuilder.setEstimatedDateTime(resultSet.getString(11));
-            if (resultSet.getBytes(12) != null) commonBuilder.setObservedDateTime(resultSet.getString(12));
+            if (resultSet.getBytes(7) != null)
+                commonBuilder.setIsTargetedAtJourneyPatternPointGid(resultSet.getLong(7));
+            if (resultSet.getBytes(8) != null)
+                commonBuilder.setWasObservedAtJourneyPatternPointGid(resultSet.getLong(8));
+            if (resultSet.getBytes(9) != null)
+                toUtcEpochMs(resultSet.getString(9)).map(commonBuilder::setTimetabledLatestUtcDateTimeMs);
+            if (resultSet.getBytes(10) != null)
+                toUtcEpochMs(resultSet.getString(10)).map(commonBuilder::setTargetUtcDateTimeMs);
+            if (resultSet.getBytes(11) != null)
+                toUtcEpochMs(resultSet.getString(11)).map(commonBuilder::setEstimatedUtcDateTimeMs);
+            if (resultSet.getBytes(12) != null)
+                toUtcEpochMs(resultSet.getString(12)).map(commonBuilder::setObservedUtcDateTimeMs);
             commonBuilder.setState(resultSet.getLong(13));
             commonBuilder.setType(resultSet.getInt(14));
             commonBuilder.setIsValidYesNo(resultSet.getBoolean(15));
-            commonBuilder.setLastModifiedUtcDateTime(eventTimeInSecs);
+
+            String lastModified = resultSet.getTimestamp(16).toString();
+            final long eventTimestampMs = toUtcEpochMs(lastModified).get();
+            commonBuilder.setLastModifiedUtcDateTimeMs(eventTimestampMs);
 
             PubtransTableProtos.Common common = commonBuilder.build();
 
@@ -65,7 +68,7 @@ public class ArrivalHandler extends PubtransTableHandler {
             final long jppId = common.getIsTargetedAtJourneyPatternPointGid();
             final byte[] data = arrival.toByteArray();
 
-            Optional<TypedMessageBuilder<byte[]>> maybeBuilder = createMessage(key, eventTimeInSecs, dvjId, jppId, data);
+            Optional<TypedMessageBuilder<byte[]>> maybeBuilder = createMessage(key, eventTimestampMs, dvjId, jppId, data);
             maybeBuilder.ifPresent(messageBuilderQueue::add);
         }
 

--- a/src/main/java/fi/hsl/transitdata/pulsarpubtransconnect/DepartureHandler.java
+++ b/src/main/java/fi/hsl/transitdata/pulsarpubtransconnect/DepartureHandler.java
@@ -1,5 +1,6 @@
 package fi.hsl.transitdata.pulsarpubtransconnect;
 
+import fi.hsl.common.pulsar.PulsarApplicationContext;
 import fi.hsl.common.transitdata.TransitdataProperties;
 import fi.hsl.common.transitdata.proto.PubtransTableProtos;
 import org.apache.pulsar.client.api.Producer;
@@ -16,8 +17,8 @@ import java.util.Queue;
 
 public class DepartureHandler extends PubtransTableHandler {
 
-    public DepartureHandler(Jedis jedis, Producer<byte[]> producer) {
-        super(jedis, producer, TransitdataProperties.ProtobufSchema.PubtransRoiDeparture);
+    public DepartureHandler(PulsarApplicationContext context) {
+        super(context, TransitdataProperties.ProtobufSchema.PubtransRoiDeparture);
     }
 
     @Override
@@ -44,14 +45,6 @@ public class DepartureHandler extends PubtransTableHandler {
                 commonBuilder.setIsTargetedAtJourneyPatternPointGid(resultSet.getLong(7));
             if (resultSet.getBytes(8) != null)
                 commonBuilder.setWasObservedAtJourneyPatternPointGid(resultSet.getLong(8));
-            /*if (resultSet.getBytes(12) != null)
-                commonBuilder.setTimetabledLatestDateTime(resultSet.getString(12));
-            if (resultSet.getBytes(13) != null)
-                commonBuilder.setTargetDateTime(resultSet.getString(13));
-            if (resultSet.getBytes(14) != null)
-                commonBuilder.setEstimatedDateTime(resultSet.getString(14));
-            if (resultSet.getBytes(15) != null)
-                commonBuilder.setObservedDateTime(resultSet.getString(15));*/
             if (resultSet.getBytes(12) != null)
                 toUtcEpochMs(resultSet.getString(12)).map(commonBuilder::setTimetabledLatestUtcDateTimeMs);
             if (resultSet.getBytes(13) != null)
@@ -63,7 +56,6 @@ public class DepartureHandler extends PubtransTableHandler {
             commonBuilder.setState(resultSet.getLong(16));
             commonBuilder.setType(resultSet.getInt(17));
             commonBuilder.setIsValidYesNo(resultSet.getBoolean(18));
-            //commonBuilder.setLastModifiedUtcDateTime(eventTimeInSecs);
 
             final long eventTimestampMs = toUtcEpochMs(resultSet.getTimestamp(19).toString()).get();
             commonBuilder.setLastModifiedUtcDateTimeMs(eventTimestampMs);

--- a/src/main/java/fi/hsl/transitdata/pulsarpubtransconnect/DepartureHandler.java
+++ b/src/main/java/fi/hsl/transitdata/pulsarpubtransconnect/DepartureHandler.java
@@ -31,31 +31,42 @@ public class DepartureHandler extends PubtransTableHandler {
 
             PubtransTableProtos.Common.Builder commonBuilder = PubtransTableProtos.Common.newBuilder();
 
-            //This is the LastModifiedUTCDateTime from the database. It will be used in the actual protobuf message and
-            //the Pulsar message eventTime field
-            long eventTime = resultSet.getTimestamp(19).getTime();
-            if (eventTime > tempTimeStamp)
-                tempTimeStamp = eventTime;
-            final long eventTimeInSecs = eventTime / 1000;
-
             //We're hardcoding the version number to proto file to ease syncing with changes, however we still need to set it since it's a required field
             commonBuilder.setSchemaVersion(commonBuilder.getSchemaVersion());
             commonBuilder.setId(resultSet.getLong(1));
             commonBuilder.setIsOnDatedVehicleJourneyId(resultSet.getLong(2));
-            if (resultSet.getBytes(3) != null) commonBuilder.setIsOnMonitoredVehicleJourneyId(resultSet.getLong(3));
+            if (resultSet.getBytes(3) != null)
+                commonBuilder.setIsOnMonitoredVehicleJourneyId(resultSet.getLong(3));
             commonBuilder.setJourneyPatternSequenceNumber(resultSet.getInt(4));
             commonBuilder.setIsTimetabledAtJourneyPatternPointGid(resultSet.getLong(5));
             commonBuilder.setVisitCountNumber(resultSet.getInt(6));
-            if (resultSet.getBytes(7) != null) commonBuilder.setIsTargetedAtJourneyPatternPointGid(resultSet.getLong(7));
-            if (resultSet.getBytes(8) != null) commonBuilder.setWasObservedAtJourneyPatternPointGid(resultSet.getLong(8));
-            if (resultSet.getBytes(12) != null) commonBuilder.setTimetabledLatestDateTime(resultSet.getString(12));
-            if (resultSet.getBytes(13) != null) commonBuilder.setTargetDateTime(resultSet.getString(13));
-            if (resultSet.getBytes(14) != null) commonBuilder.setEstimatedDateTime(resultSet.getString(14));
-            if (resultSet.getBytes(15) != null) commonBuilder.setObservedDateTime(resultSet.getString(15));
+            if (resultSet.getBytes(7) != null)
+                commonBuilder.setIsTargetedAtJourneyPatternPointGid(resultSet.getLong(7));
+            if (resultSet.getBytes(8) != null)
+                commonBuilder.setWasObservedAtJourneyPatternPointGid(resultSet.getLong(8));
+            /*if (resultSet.getBytes(12) != null)
+                commonBuilder.setTimetabledLatestDateTime(resultSet.getString(12));
+            if (resultSet.getBytes(13) != null)
+                commonBuilder.setTargetDateTime(resultSet.getString(13));
+            if (resultSet.getBytes(14) != null)
+                commonBuilder.setEstimatedDateTime(resultSet.getString(14));
+            if (resultSet.getBytes(15) != null)
+                commonBuilder.setObservedDateTime(resultSet.getString(15));*/
+            if (resultSet.getBytes(12) != null)
+                toUtcEpochMs(resultSet.getString(12)).map(commonBuilder::setTimetabledLatestUtcDateTimeMs);
+            if (resultSet.getBytes(13) != null)
+                toUtcEpochMs(resultSet.getString(13)).map(commonBuilder::setTargetUtcDateTimeMs);
+            if (resultSet.getBytes(14) != null)
+                toUtcEpochMs(resultSet.getString(14)).map(commonBuilder::setEstimatedUtcDateTimeMs);
+            if (resultSet.getBytes(15) != null)
+                toUtcEpochMs(resultSet.getString(15)).map(commonBuilder::setObservedUtcDateTimeMs);
             commonBuilder.setState(resultSet.getLong(16));
             commonBuilder.setType(resultSet.getInt(17));
             commonBuilder.setIsValidYesNo(resultSet.getBoolean(18));
-            commonBuilder.setLastModifiedUtcDateTime(eventTimeInSecs);
+            //commonBuilder.setLastModifiedUtcDateTime(eventTimeInSecs);
+
+            final long eventTimestampMs = toUtcEpochMs(resultSet.getTimestamp(19).toString()).get();
+            commonBuilder.setLastModifiedUtcDateTimeMs(eventTimestampMs);
 
             PubtransTableProtos.Common common = commonBuilder.build();
 
@@ -71,7 +82,7 @@ public class DepartureHandler extends PubtransTableHandler {
             final long jppId = common.getIsTargetedAtJourneyPatternPointGid();
             final byte[] data = departure.toByteArray();
 
-            Optional<TypedMessageBuilder<byte[]>> maybeBuilder = createMessage(key, eventTimeInSecs, dvjId, jppId, data);
+            Optional<TypedMessageBuilder<byte[]>> maybeBuilder = createMessage(key, eventTimestampMs, dvjId, jppId, data);
             maybeBuilder.ifPresent(messageBuilderQueue::add);
         }
 

--- a/src/main/java/fi/hsl/transitdata/pulsarpubtransconnect/Main.java
+++ b/src/main/java/fi/hsl/transitdata/pulsarpubtransconnect/Main.java
@@ -67,7 +67,7 @@ public class Main {
             final PulsarApplication app = PulsarApplication.newInstance(config);
             PulsarApplicationContext context = app.getContext();
 
-            final PubtransConnector connector = PubtransConnector.newInstance(connection, context.getJedis(), context.getProducer(), config, type);
+            final PubtransConnector connector = PubtransConnector.newInstance(connection, context, type);
 
             final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
             log.info("Starting scheduler");

--- a/src/main/java/fi/hsl/transitdata/pulsarpubtransconnect/PubtransTableHandler.java
+++ b/src/main/java/fi/hsl/transitdata/pulsarpubtransconnect/PubtransTableHandler.java
@@ -43,11 +43,12 @@ public abstract class PubtransTableHandler {
     }
 
     public static Optional<Long> toUtcEpochMs(String localTimestamp) {
+        if (localTimestamp == null || localTimestamp.isEmpty())
+            return Optional.empty();
+
         try {
-            DateTimeFormatter formatter =
-                    DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.S[SS]");
-            LocalDateTime dt = LocalDateTime.parse(localTimestamp, formatter);
-            long epochMs = dt.toEpochSecond(ZoneOffset.UTC) * 1000;
+            LocalDateTime dt = LocalDateTime.parse(localTimestamp.replace(" ", "T")); // Make java.sql.Timestamp ISO compatible
+            long epochMs = dt.toInstant(ZoneOffset.UTC).toEpochMilli();
             return Optional.of(epochMs);
         }
         catch (Exception e) {

--- a/src/main/java/fi/hsl/transitdata/pulsarpubtransconnect/PubtransTableHandler.java
+++ b/src/main/java/fi/hsl/transitdata/pulsarpubtransconnect/PubtransTableHandler.java
@@ -9,6 +9,11 @@ import redis.clients.jedis.Jedis;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -35,6 +40,20 @@ public abstract class PubtransTableHandler {
 
     public void setLastModifiedTimeStamp(long ts) {
         this.lastModifiedTimeStamp = ts;
+    }
+
+    public static Optional<Long> toUtcEpochMs(String localTimestamp) {
+        try {
+            DateTimeFormatter formatter =
+                    DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.S[SS]");
+            LocalDateTime dt = LocalDateTime.parse(localTimestamp, formatter);
+            long epochMs = dt.toEpochSecond(ZoneOffset.UTC) * 1000;
+            return Optional.of(epochMs);
+        }
+        catch (Exception e) {
+            log.error("Failed to parse datetime from " + localTimestamp, e);
+            return Optional.empty();
+        }
     }
 
     //TODO finetune SQL so that we can use common method to parse most of the fields. now derived classes contain a lot of duplicate code.

--- a/src/main/resources/arrival.conf
+++ b/src/main/resources/arrival.conf
@@ -18,6 +18,9 @@ redis {
 pubtrans {
   longName="[ptROI_Community].[dbo].[Arrival]"
   shortName="ARR"
+  # Pubtrans timestamps are not stored with the zone offset so we need to define how we should interpret the timestamps.
+  timezone="Europe/Helsinki"
+  timezone=${?PUBTRANS_DATA_TIMEZONE}
 }
 
 application {

--- a/src/main/resources/departure.conf
+++ b/src/main/resources/departure.conf
@@ -18,6 +18,9 @@ redis {
 pubtrans {
   longName="[ptROI_Community].[dbo].[Departure]"
   shortName="DEP"
+  # Pubtrans timestamps are not stored with the zone offset so we need to define how we should interpret the timestamps.
+  timezone="Europe/Helsinki"
+  timezone=${?PUBTRANS_DATA_TIMEZONE}
 }
 
 application {

--- a/src/test/java/fi/hsl/transitdata/pulsarpubtransconnect/PubtransTableHandlerTest.java
+++ b/src/test/java/fi/hsl/transitdata/pulsarpubtransconnect/PubtransTableHandlerTest.java
@@ -9,11 +9,35 @@ import static org.junit.Assert.assertTrue;
 
 public class PubtransTableHandlerTest {
     @Test
-    public void testTimestampConversion() {
-        assertEquals((Long)1545695999000L, PubtransTableHandler.toUtcEpochMs("2018-12-24 23:59:59.0").get());
-        assertEquals((Long)1545695999001L, PubtransTableHandler.toUtcEpochMs("2018-12-24 23:59:59.001").get());
-        assertEquals(Optional.empty(), PubtransTableHandler.toUtcEpochMs(""));
-        assertEquals(Optional.empty(), PubtransTableHandler.toUtcEpochMs(null));
-        assertEquals((Long)1540551514557L, PubtransTableHandler.toUtcEpochMs("2018-10-26 10:58:34.557").get());
+    public void testTimestampConversionInUTC() {
+        final String timezone = "UTC";
+        assertEquals((Long)1545695999000L, PubtransTableHandler.toUtcEpochMs("2018-12-24 23:59:59.0", timezone).get());
+        assertEquals((Long)1545695999001L, PubtransTableHandler.toUtcEpochMs("2018-12-24 23:59:59.001", timezone).get());
+        assertEquals(Optional.empty(), PubtransTableHandler.toUtcEpochMs("", timezone));
+        assertEquals(Optional.empty(), PubtransTableHandler.toUtcEpochMs(null, timezone));
+        assertEquals((Long)1540551514557L, PubtransTableHandler.toUtcEpochMs("2018-10-26 10:58:34.557", timezone).get());
     }
+
+    @Test
+    public void testTimestampConversionInEET() {
+        final String timezone = "Europe/Helsinki";
+        assertEquals((Long)1545688799000L, PubtransTableHandler.toUtcEpochMs("2018-12-24 23:59:59.0", timezone).get());
+        assertEquals((Long)1545688799001L, PubtransTableHandler.toUtcEpochMs("2018-12-24 23:59:59.001", timezone).get());
+        assertEquals(Optional.empty(), PubtransTableHandler.toUtcEpochMs("", timezone));
+        assertEquals(Optional.empty(), PubtransTableHandler.toUtcEpochMs(null, timezone));
+        assertEquals((Long)1540540714557L, PubtransTableHandler.toUtcEpochMs("2018-10-26 10:58:34.557", timezone).get());
+    }
+
+    @Test
+    public void testDaylightSavings() {
+        final String timezone = "Europe/Helsinki";
+        final long winterTime = PubtransTableHandler.toUtcEpochMs("2018-03-25 02:59:59.999", timezone).get();
+        final long summerTime = PubtransTableHandler.toUtcEpochMs("2018-03-25 03:00:00.000", timezone).get();
+        assertEquals(summerTime, winterTime + 1);
+
+        final long summerTimeWithDaylightSavings = PubtransTableHandler.toUtcEpochMs("2018-03-25 04:00:00.000", timezone).get();
+        assertEquals(summerTime, summerTimeWithDaylightSavings);
+        assertEquals(summerTimeWithDaylightSavings, winterTime + 1);
+    }
+
 }

--- a/src/test/java/fi/hsl/transitdata/pulsarpubtransconnect/PubtransTableHandlerTest.java
+++ b/src/test/java/fi/hsl/transitdata/pulsarpubtransconnect/PubtransTableHandlerTest.java
@@ -5,13 +5,15 @@ import org.junit.Test;
 import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class PubtransTableHandlerTest {
     @Test
     public void testTimestampConversion() {
         assertEquals((Long)1545695999000L, PubtransTableHandler.toUtcEpochMs("2018-12-24 23:59:59.0").get());
-        assertEquals((Long)1545695999000L, PubtransTableHandler.toUtcEpochMs("2018-12-24 23:59:59.000").get());
+        assertEquals((Long)1545695999001L, PubtransTableHandler.toUtcEpochMs("2018-12-24 23:59:59.001").get());
         assertEquals(Optional.empty(), PubtransTableHandler.toUtcEpochMs(""));
         assertEquals(Optional.empty(), PubtransTableHandler.toUtcEpochMs(null));
+        assertEquals((Long)1540551514557L, PubtransTableHandler.toUtcEpochMs("2018-10-26 10:58:34.557").get());
     }
 }

--- a/src/test/java/fi/hsl/transitdata/pulsarpubtransconnect/PubtransTableHandlerTest.java
+++ b/src/test/java/fi/hsl/transitdata/pulsarpubtransconnect/PubtransTableHandlerTest.java
@@ -1,0 +1,17 @@
+package fi.hsl.transitdata.pulsarpubtransconnect;
+
+import org.junit.Test;
+
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+
+public class PubtransTableHandlerTest {
+    @Test
+    public void testTimestampConversion() {
+        assertEquals((Long)1545695999000L, PubtransTableHandler.toUtcEpochMs("2018-12-24 23:59:59.0").get());
+        assertEquals((Long)1545695999000L, PubtransTableHandler.toUtcEpochMs("2018-12-24 23:59:59.000").get());
+        assertEquals(Optional.empty(), PubtransTableHandler.toUtcEpochMs(""));
+        assertEquals(Optional.empty(), PubtransTableHandler.toUtcEpochMs(null));
+    }
+}


### PR DESCRIPTION
- Use UTC epoch milliseconds in all timestamps in internal pulsar messages.