### PR TITLE
feat/fix-query

### DIFF
--- a/src/main/java/fi/hsl/transitdata/pulsarpubtransconnect/PubtransConnector.java
+++ b/src/main/java/fi/hsl/transitdata/pulsarpubtransconnect/PubtransConnector.java
@@ -73,6 +73,8 @@ public class PubtransConnector {
                 .append(shortName)
                 .append(" WHERE ")
                 .append(shortName).append(".LastModifiedUTCDateTime > ? ")
+                .append(" AND ")
+                .append(shortName).append(".HasServiceRequirementId IS NOT NULL ")
                 .append(" ORDER BY ")
                 .append(shortName).append(".LastModifiedUTCDateTime, ")
                 .append(shortName).append(".IsOnDatedVehicleJourneyId, ")


### PR DESCRIPTION
 - Add "HasServiceRequirementId IS NOT NULL" to query in order to eliminate "Failed to get Trip Info for dvj-id..." errors

Who to ask if this makes sense? @laaksma ?